### PR TITLE
feat: add option of launch.sh to avoid unknown flags issue

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -7,24 +7,23 @@ if [ ! -f .env ]; then
 fi
 source .env
 
-function help() {
+function showhelp () {
    # Display Help
    echo
    echo "Usage: $0 [option...]"
    echo "options:"
-   echo "-h, --help       Print this Help."
-   echo "-d, --daemon     Start with a daemon mode."
+   echo "  -h       Print this help."
+   echo "  -d       Start in daemon mode."
    echo
 }
 
-while getopts ":h:d" option; do
+while getopts "hd" option; do
    case $option in
       h)
-         help
+         showhelp
          exit;;
       d)
          options="-d"
-         echo "-d option"
          ;;
      \?) # incorrect option
          echo "Error: Invalid option"

--- a/launch.sh
+++ b/launch.sh
@@ -7,5 +7,30 @@ if [ ! -f .env ]; then
 fi
 source .env
 
+function help() {
+   # Display Help
+   echo
+   echo "Usage: $0 [option...]"
+   echo "options:"
+   echo "-h, --help       Print this Help."
+   echo "-d, --daemon     Start with a daemon mode."
+   echo
+}
+
+while getopts ":h:d" option; do
+   case $option in
+      h)
+         help
+         exit;;
+      d)
+         options="-d"
+         echo "-d option"
+         ;;
+     \?) # incorrect option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
+
 # On newer versions, docker-compose is docker compose
-docker compose up -d --remove-orphans || docker-compose up -d --remove-orphans
+docker compose up $options --remove-orphans || docker-compose up $options --remove-orphans


### PR DESCRIPTION
This PR is to add an option function for the user to selectively use foreground mode and background mode (i.e., daemon mode). Also, depending on the version of docker composer, the -d (daemon mode) option may or may not be present. Therefore, this is to deal effectively with these situations.


Resolved #107 

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>