### PR TITLE
github: added CODEOWNERS for automated review list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ converter                    @moyix
 copilot_proxy                @moyix @thakkarparth007
 python_backend               @moyix @thakkarparth007
 tests                        @moyix
-documentation                @moyix @thakkarparth007 @fdegier @leemgs
-docker-compose.yaml          @moyix @thakkarparth007 @fdegier @leemgs
-Dockerfile                   @moyix @thakkarparth007 @fdegier @leemgs
-copilot_proxy/Dockerfile     @moyix @thakkarparth007 @fdegier @leemgs
+documentation                @moyix @thakkarparth007 @fdegier
+docker-compose.yaml          @moyix @thakkarparth007 @fdegier
+Dockerfile                   @moyix @thakkarparth007 @fdegier 
+copilot_proxy/Dockerfile     @moyix @thakkarparth007 @fdegier 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,12 @@
 # all member IDs directly to avoid unexpected situations.
 
 # In order that all members of a repository are supposed to review each other
-* @moyix
-documentation @moyix @leemgs
+* @moyix @thakkarparth007 @fdegier
+converter                    @moyix
+copilot_proxy                @moyix @thakkarparth007
+python_backend               @moyix @thakkarparth007
+tests                        @moyix
+documentation                @moyix @thakkarparth007 @fdegier @leemgs
+docker-compose.yaml          @moyix @thakkarparth007 @fdegier @leemgs
+Dockerfile                   @moyix @thakkarparth007 @fdegier @leemgs
+copilot_proxy/Dockerfile     @moyix @thakkarparth007 @fdegier @leemgs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is a comment. Each line is a file pattern followed by one or more owners.
+# For more details, visit https://help.github.com/articles/about-codeowners/
+#
+# Note that the current version of github.com (community edition) does not
+# translate "@org/team-name" correctly, although the GitHub webpage depicts how
+# to use "@org/team-name" as well as "@username" format. So, We need to append
+# all member IDs directly to avoid unexpected situations.
+
+# In order that all members of a repository are supposed to review each other
+* @moyix
+documentation @moyix @leemgs


### PR DESCRIPTION
This commit is to enable the CODEOWNERS template that is provieded by GitHub infrastructure. It is to improve the code review's effort and time on upcoming PRs by adding this template.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>