### PR TITLE
github: added ISSUE_TEMPLATE for issue maintenance

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+Having problems with a source code of a github repository?
+
+Having problems with the FauxPilot that controls the build process?
+
+Good to go? Then please remove these lines above, including this one, and help us understand your issue by answering the following:
+
+# Issue Description
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+Further Information
+===============
+* A link to an output result showing the issue
+* Exact OS version

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example, I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Support_request.md
+++ b/.github/ISSUE_TEMPLATE/Support_request.md
@@ -1,0 +1,13 @@
+---
+name: Support Request
+about: Report a problem with our project source code
+
+---
+
+![WARNING](https://media.giphy.com/media/Zsx8ZwmX3ajny/giphy.gif)
+
+Please only create issues/feature requests for the project here.
+
+For support contact our project maintainer(s), they meet online in a 'Issues' list.
+There you can ask questions if you have trouble understanding something, seek advice and mingle with other project members.
+For further information see 'Wiki' page.


### PR DESCRIPTION
This commit is to enable the ISSUE_TEMPLATE to maintain issues of FauxPilot by adding the ISSUE_TEMPLATE files into the FauxPilot repository.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>