### PR TITLE
github: added action runner to welcome  new contributors

### DIFF
--- a/.github/workflows/welcome-new-contributor.yml
+++ b/.github/workflows/welcome-new-contributor.yml
@@ -1,0 +1,21 @@
+name: 'Welcome New Contributors'
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  welcome-new-contributor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Greet the contributor'
+        uses: garg3133/welcome-new-contributors@v1.2
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          is-oauth-token: true
+          issue-message: 'Hello there, thanks for opening your first issue. We
+welcome you to the FauxPilot community!'
+          pr-message: 'Hello there, thanks for opening your first Pull
+Request. Someone will review it soon.'


### PR DESCRIPTION
This commit is to append an GitHub Action to welcome new contributors into the FauxPilot community. This action is to post automatically a welcome message whenever a new contributor opens a first issue or PR in this repository.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>