### PR TITLE
Add FAUXPILOT_TRUNCATE_PROMPT to truncate prompts

### DIFF
--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -13,10 +13,20 @@ from utils.errors import FauxPilotException
 
 logging.config.dictConfig(uvicorn_logger)
 
+def _strtobool(string: str) -> bool:
+    """Copy of distutils.util.strtobool, since it will be removed in Python 3.11"""
+    if string.lower() in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif string.lower() in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"string {string} could not be parsed as a booelan option")
+
 codegen = CodeGenProxy(
     host=os.environ.get("TRITON_HOST", "triton"),
     port=os.environ.get("TRITON_PORT", 8001),
-    verbose=os.environ.get("TRITON_VERBOSITY", False)
+    verbose=os.environ.get("TRITON_VERBOSITY", False),
+    truncate_prompt_to_max_tokens=_strtobool(os.environ.get("FAUXPILOT_TRUNCATE_PROMPT", "1"))
 )
 
 app = FastAPI(

--- a/setup.sh
+++ b/setup.sh
@@ -47,12 +47,20 @@ else
 fi
 mkdir -p "$MODELS_ROOT_DIR"
 
+read -rp "Do you want to automatically truncate prompts to fit within the model? (otherwise the model will throw an error when given too much data) y/n [y]: " TRUNCATE_PROMPT
+if [[ ${TRUNCATE_PROMPT:-y} =~ ^[Nn]$ ]]; then
+    FAUXPILOT_TRUNCATE_PROMPT=0
+else
+    FAUXPILOT_TRUNCATE_PROMPT=1
+fi
+
 # Write .env
 echo "NUM_GPUS=${NUM_GPUS}" >> .env
 echo "GPUS=$(seq 0 $(( NUM_GPUS - 1)) | paste -s -d ',' -)" >> .env
 echo "API_EXTERNAL_PORT=${API_EXTERNAL_PORT}" >> .env
 echo "TRITON_HOST=${TRITON_HOST}" >> .env
 echo "TRITON_PORT=${TRITON_PORT}" >> .env
+echo "FAUXPILOT_TRUNCATE_PROMPT=${FAUXPILOT_TRUNCATE_PROMPT}" >> .env
 
 ############### Backend specific configuration ###############
 


### PR DESCRIPTION
Adds a new environment variable called `FAUXPILOT_TRUNCATE_PROMPT` that when enabled, will automatically truncate prompts so that they fit within the model.

This avoids `TokensExceedsMaximum` errors when using FauxPilot with larger files by truncating the prompt  on clients like [GitLab's VS Code plugin](https://gitlab.com/gitlab-org/gitlab-vscode-extension).

**I've set this to enabled by default, since I believe this will make for a better user experience for code auto-completion.** However, from a quick scan of the docs, **it doesn't look like the OpenAI API supports truncating**, so it might be better to make it disabled by default if you want to keep FauxPilot's behavior as close to OpenAI as possible.

---

I've added a test case that checks the behavior when this variable is True or False.

Additionally, I've confirmed that [GitLab's VS Code plugin](https://gitlab.com/gitlab-org/gitlab-vscode-extension)'s FauxPilot suggestions now works on large files when it previously didn't.