### PR TITLE
Fix json formatting issue with streaming

### DIFF
--- a/copilot_proxy/utils/codegen.py
+++ b/copilot_proxy/utils/codegen.py
@@ -234,8 +234,8 @@ class CodeGenProxy:
         for c in choices:
             completion['id'] = self.random_completion_id()
             completion['choices'] = [c]
-            yield f'data: {json.dumps(completion)}\n\n'
-        yield 'data: [DONE]\n\n'
+            yield f'{json.dumps(completion)}\n\n'
+        yield '[DONE]\n\n'
 
     def non_streamed_response(self, completion, choices) -> str:
         completion['id'] = self.random_completion_id()

--- a/copilot_proxy/utils/codegen.py
+++ b/copilot_proxy/utils/codegen.py
@@ -234,8 +234,8 @@ class CodeGenProxy:
         for c in choices:
             completion['id'] = self.random_completion_id()
             completion['choices'] = [c]
-            yield f'{json.dumps(completion)}\n\n'
-        yield '[DONE]\n\n'
+            yield f'{json.dumps(completion)}'
+        yield '[DONE]'
 
     def non_streamed_response(self, completion, choices) -> str:
         completion['id'] = self.random_completion_id()


### PR DESCRIPTION
See this and this [comment](https://github.com/fauxpilot/fauxpilot/issues/1#issuecomment-1357174072) for context.

Currently the streaming response looks like the following:

```
data: data: {"id": "cmpl-6TMRfgynXT3wpdrNOVZgS4is5DadC", "model": "codegen", "object": "text_completion", "created": 1671816259, "choices": [{"text": ",\n        )\n        return self._s", "index": 0, "finish_reason": "length", "logprobs": null}], "usage": {"completion_tokens": 10, "prompt_tokens": 1, "total_tokens": 11}}
data: 
data: 

data: data: [DONE]
data: 
data: 
```

When hooking up Copilot with FauxPilot, Copilot complains about badly formatted JSON data. That's because it doesn't expect the second "data:". This PR fixes it. The first "data:" string seems to be added by FastAPI, but I'm not 100% sure if that's the real culprit.

After this PR, the output looks like this:

```
data: {"id": "cmpl-6TMRfgynXT3wpdrNOVZgS4is5DadC", "model": "codegen", "object": "text_completion", "created": 1671816259, "choices": [{"text": ",\n        )\n        return self._s", "index": 0, "finish_reason": "length", "logprobs": null}], "usage": {"completion_tokens": 10, "prompt_tokens": 1, "total_tokens": 11}}

data: [DONE]
```

Apart from the leading `data: `, I've also removed the trailing newlines. Copilot doesn't seem to complain! Although idk if the Gitlab/any other extension might start facing issues.

Signed-off-by: Parth Thakkar <thakkarparth007@gmail.com>