### PR TITLE
fix: improved the docker compose statement to handle various docker env

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -167,7 +167,7 @@ function python_backend(){
     echo "HF_CACHE_DIR=${HF_CACHE_DIR}" >> .env
 
     python3 ./python_backend/init_model.py --model_name "${MODEL}" --org_name "${ORG}" --model_dir "${MODELS_ROOT_DIR}" --use_int8 "${USE_INT8}"
-    bash -c "source .env ; docker compose build"
+    bash -c "source .env ; docker compose build || docker-compose build"
 }
 
 # choose backend


### PR DESCRIPTION
This commit is to handle both "docker-compose" and "docker compose" environment while running the python_backend function in the setup.sh.

* How to evaluate:
1. ./setup.sh
2. Self assessment:**
 - Build test: [*]Passed [ ]Failed [ ]Skipped
 - Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Geunsik Lim <leemgs@gmail.com>
Signed-off-by: Geunsik Lim <geunsik.lim@samsuang.com>
```

