### PR TITLE
Fix docker compose invocation

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -31,5 +31,10 @@ while getopts "hd" option; do
    esac
 done
 
-# On newer versions, docker-compose is docker compose
-docker compose up $options --remove-orphans || docker-compose up $options --remove-orphans
+# On versions above 20.10.2, docker-compose is docker compose
+smaller=$(printf "$(docker --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+')\n20.10.2" | sort -V | head -n1)
+if [[ "$smaller" == "20.10.2" ]]; then
+  docker compose up $options --remove-orphans --build
+else
+  docker-compose up $options --remove-orphans --build
+fi;


### PR DESCRIPTION
1. Make sure we don't call docker-compose if 'docker compose' is available. The `a || b` construct in launch.sh caused `b` to be executed if `a` stopped "abnormally" (which includes pressing ctrl+c).
2. Automatically build the container (will be cached by docker, so no overhead) (fixes #140)

Signed-off-by: Parth Thakkar <thakkarparth007@gmail.com>

