### PR TITLE
Add fake copilot authentication to copilot proxy

### DIFF
--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -35,6 +35,7 @@ async def fauxpilot_handler(request: Request, exc: FauxPilotException):
     )
 
 @app.post("/v1/engines/codegen/completions")
+@app.post("/v1/engines/copilot-codex/completions")
 @app.post("/v1/completions")
 async def completions(data: OpenAIinput):
     data = data.dict()

--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -34,6 +34,7 @@ async def fauxpilot_handler(request: Request, exc: FauxPilotException):
         content=exc.json()
     )
 
+# Used to support copilot.vim 
 @app.get("/copilot_internal/v2/token")
 def get_copilot_token():
     content = {'token': '1', 'expires_at': 2600000000, 'refresh_in': 900}
@@ -43,6 +44,7 @@ def get_copilot_token():
     )
 
 @app.post("/v1/engines/codegen/completions")
+# Used to support copilot.vim 
 @app.post("/v1/engines/copilot-codex/completions")
 @app.post("/v1/completions")
 async def completions(data: OpenAIinput):

--- a/copilot_proxy/app.py
+++ b/copilot_proxy/app.py
@@ -34,6 +34,14 @@ async def fauxpilot_handler(request: Request, exc: FauxPilotException):
         content=exc.json()
     )
 
+@app.get("/copilot_internal/v2/token")
+def get_copilot_token():
+    content = {'token': '1', 'expires_at': 2600000000, 'refresh_in': 900}
+    return JSONResponse(
+        status_code=200,
+        content=content
+    )
+
 @app.post("/v1/engines/codegen/completions")
 @app.post("/v1/engines/copilot-codex/completions")
 @app.post("/v1/completions")


### PR DESCRIPTION
Also, added route for `/v1/engines/copilot-codex/completions` to make copliot proxy more compatible with official copilot plugins (eg. copilot.vim).

With this PR, there is no need to delopy a new server for fake copilot authentication to use fauxpilot in copilot.vim.

See also: #72