### PR TITLE
Fix excess argument

### DIFF
--- a/converter/huggingface_gptj_convert.py
+++ b/converter/huggingface_gptj_convert.py
@@ -168,7 +168,7 @@ def split_and_convert(args):
                                                                                  ft_model_name_pattern[i])
 
                     pool.starmap(split_and_convert_process,
-                                 [(0, saved_dir, factor, new_name, args,
+                                 [(0, saved_dir, factor, new_name,
                                    weights)], )
 
     pool.close()


### PR DESCRIPTION
---
## 1. General Description
The latest commit broke the HF GPTJ converter because the pool mapper calls `split_and_convert_process` with one argument too many ("args"). This PR simply removes the excess argument.
```
pool.starmap(
                        split_and_convert_process,
                        [(0, saved_dir, factor, new_name, args, weights)],
                    )
def split_and_convert_process(i, saved_dir, factor, key, val):
```



## 2. Changes proposed in this PR:
1. Remove excess argument

## 3. How to evaluate:
1. Build convert container
2. Try to convert any HF model

1. Self assessment:
 - [X] Successfully build locally `docker-compose build`:
 - [X] Successfully tested the full solution locally
