### PR TITLE
Remove Gitlab VSCode Extension suggestion

### DIFF
--- a/documentation/client.md
+++ b/documentation/client.md
@@ -65,8 +65,3 @@ Another issue with using the Copilot plugin is that its tokenizer (the component
 
 Have fun!
 
-## GitLab - VS Code extentension  
-
-Another option is to use the [GitLab VS Code extension](https://marketplace.visualstudio.com/items?itemName=GitLab.gitlab-workflow) which has support for FauxPilot.  
-
-Contributions are encouraged :smile: https://gitlab.com/gitlab-org/gitlab-vscode-extension


### PR DESCRIPTION
## 1. General Description
It is no longer supported: https://gitlab.com/gitlab-org/gitlab-vscode-extension/-/merge_requests/697


## 2. Changes proposed in this PR:
Change client documentation

## 3. How to evaluate:
1. Check the PR linked above. The Gitlab extension no longer support third party completion servers
2. Self assessment:
 - [X] Successfully build locally `docker-compose build`:
 - [X] Successfully tested the full solution locally
